### PR TITLE
Kill forcefully stoptime seconds after trying to kill gracefully

### DIFF
--- a/src/run/statemachine/desired.rs
+++ b/src/run/statemachine/desired.rs
@@ -15,14 +15,7 @@ pub fn desire_idle(proc: &mut Process) -> (Option<ProcessState>, bool) {
             let _ = proc.kill_gracefully();
             (Some(Stopping(Instant::now())), RETAIN_DESIRED_STATE)
         }
-        Stopping(stopped_at) => {
-            if proc.config().stoptime() <= stopped_at.elapsed().as_secs() as u8 {
-                let _ = proc.kill_forcefully();
-                (Some(Idle), RETAIN_DESIRED_STATE)
-            } else {
-                (None, RETAIN_DESIRED_STATE)
-            }
-        }
+        Stopping(_) => (None, RETAIN_DESIRED_STATE),
         _ => (Some(Idle), REMOVE_DESIRED_STATE),
     }
 }
@@ -35,14 +28,7 @@ pub fn desire_ready(proc: &mut Process) -> (Option<ProcessState>, bool) {
             let _ = proc.kill_gracefully();
             (Some(Stopping(Instant::now())), RETAIN_DESIRED_STATE)
         }
-        Stopping(stopped_at) => {
-            if proc.config().stoptime() <= stopped_at.elapsed().as_secs() as u8 {
-                let _ = proc.kill_forcefully();
-                (Some(Ready), REMOVE_DESIRED_STATE)
-            } else {
-                (None, RETAIN_DESIRED_STATE)
-            }
-        }
+        Stopping(_) => (None, RETAIN_DESIRED_STATE),
         _ => (Some(Ready), REMOVE_DESIRED_STATE),
     }
 }
@@ -51,14 +37,7 @@ pub fn desire_healthy(proc: &mut Process) -> (Option<ProcessState>, bool) {
     match proc.state().clone() {
         Idle => (Some(Ready), REMOVE_DESIRED_STATE),
         Ready | HealthCheck(_) | Healthy => (None, REMOVE_DESIRED_STATE),
-        Stopping(stopped_at) => {
-            if proc.config().stoptime() <= stopped_at.elapsed().as_secs() as u8 {
-                let _ = proc.kill_forcefully();
-                (Some(Ready), REMOVE_DESIRED_STATE)
-            } else {
-                (None, RETAIN_DESIRED_STATE)
-            }
-        }
+        Stopping(_) => (None, RETAIN_DESIRED_STATE),
         _ => (Some(Ready), REMOVE_DESIRED_STATE),
     }
 }

--- a/src/run/statemachine/states.rs
+++ b/src/run/statemachine/states.rs
@@ -56,7 +56,7 @@ impl ProcessState {
             Failed(_process_state) => monitor_failed(proc),
             WaitingForRetry(retry_at) => monitor_waiting_for_retry(retry_at, proc),
             Completed => monitor_completed(proc),
-            Stopping(_) => monitor_stopping(proc),
+            Stopping(killed_at) => monitor_stopping(*killed_at, proc),
             Stopped => monitor_stopped(proc),
         }
     }


### PR DESCRIPTION
The stoptime field was ignored, added a check in monitor_stopping to kill forcefully after `stoptime` seconds.