### PR TITLE
Add option to discard output of process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bytes"
@@ -52,9 +52,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]
@@ -73,9 +73,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -91,9 +91,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "indexmap"
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "unicode-ident"
@@ -575,9 +575,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -75,7 +75,7 @@ impl Config {
     }
 
     fn parse(config_str: &str) -> Result<Self, Box<dyn Error>> {
-        let mut conf: Config = match toml::from_str(config_str) {
+        let conf: Config = match toml::from_str(config_str) {
             Ok(cnf) => cnf,
             Err(err) => {
                 return Err(err.into());
@@ -84,16 +84,6 @@ impl Config {
 
         if conf.processes.is_empty() {
             return Err("taskmaster expects at least one process to be defined to operate".into());
-        }
-
-        // Did not find a way to have serde defaults depend on other field's values.
-        for (proc_name, proc) in &mut conf.processes {
-            if proc.stdout().is_empty() {
-                proc.set_stdout(&format!("/tmp/{proc_name}.stdout"));
-            }
-            if proc.stderr().is_empty() {
-                proc.set_stderr(&format!("/tmp/{proc_name}.stderr"));
-            }
         }
 
         Ok(conf)

--- a/src/conf/proc.rs
+++ b/src/conf/proc.rs
@@ -211,9 +211,8 @@ pub struct ProcessConfig {
     /// stdout = "nginx.stdout"
     /// ```
     ///
-    /// Defaults to `/tmp/<process_name>.stdout`.
-    #[serde(default = "defaults::dflt_stdout")]
-    stdout: types::WritableFile,
+    /// Default behavior is to ignore stdout.
+    stdout: Option<types::WritableFile>,
 
     /// File the standard error of the process should be redirected to.
     ///
@@ -224,9 +223,8 @@ pub struct ProcessConfig {
     /// stderr = "nginx.stderr"
     /// ```
     ///
-    /// Defaults to `/tmp/<process_name>.stderr`.
-    #[serde(default = "defaults::dflt_stderr")]
-    stderr: types::WritableFile,
+    /// Default behavior is to ignore stderr.
+    stderr: Option<types::WritableFile>,
 
     /// Key value pairs of environment variables to be injected into the process
     /// at startup.
@@ -293,12 +291,12 @@ impl ProcessConfig {
         self.stoptime
     }
 
-    pub fn stdout(&self) -> &str {
-        self.stdout.path()
+    pub fn stdout(&self) -> &Option<WritableFile> {
+        &self.stdout
     }
 
-    pub fn stderr(&self) -> &str {
-        self.stderr.path()
+    pub fn stderr(&self) -> &Option<WritableFile> {
+        &self.stderr
     }
 
     pub fn env(&self) -> &Vec<(String, String)> {
@@ -306,11 +304,11 @@ impl ProcessConfig {
     }
 
     pub fn set_stdout(&mut self, path: &str) {
-        self.stdout = types::WritableFile::from_path(path);
+        self.stdout = Some(types::WritableFile::from_path(path));
     }
 
     pub fn set_stderr(&mut self, path: &str) {
-        self.stderr = types::WritableFile::from_path(path);
+        self.stderr = Some(types::WritableFile::from_path(path));
     }
 
     #[cfg(test)]
@@ -338,8 +336,8 @@ impl Default for ProcessConfig {
             healthcheck: HealthCheck::default(),
             stopsignals: vec![types::StopSignal(SIGTERM)],
             stoptime: 5,
-            stdout: types::WritableFile::from_path("/tmp/taskmaster_test.stdout"),
-            stderr: types::WritableFile::from_path("/tmp/taskmaster_test.stderr"),
+            stdout: Some(types::WritableFile::from_path("/tmp/taskmaster_test.stdout")),
+            stderr: Some(types::WritableFile::from_path("/tmp/taskmaster_test.stderr")),
             env: Vec::new(),
         }
     }
@@ -403,12 +401,12 @@ impl ProcessConfig {
     }
 
     pub fn set_test_stdout(&mut self, path: &str) -> &mut Self {
-        self.stdout = WritableFile::from_path(path);
+        self.stdout = Some(WritableFile::from_path(path));
         self
     }
 
     pub fn set_test_stderr_test(&mut self, path: &str) -> &mut Self {
-        self.stderr = WritableFile::from_path(path);
+        self.stderr = Some(WritableFile::from_path(path));
         self
     }
 

--- a/src/conf/proc.rs
+++ b/src/conf/proc.rs
@@ -303,12 +303,14 @@ impl ProcessConfig {
         &self.env
     }
 
-    pub fn set_stdout(&mut self, path: &str) {
+    pub fn set_stdout(&mut self, path: &str) -> &mut Self {
         self.stdout = Some(types::WritableFile::from_path(path));
+        self
     }
 
-    pub fn set_stderr(&mut self, path: &str) {
+    pub fn set_stderr(&mut self, path: &str) -> &mut Self {
         self.stderr = Some(types::WritableFile::from_path(path));
+        self
     }
 
     #[cfg(test)]

--- a/src/conf/proc.rs
+++ b/src/conf/proc.rs
@@ -338,8 +338,8 @@ impl Default for ProcessConfig {
             healthcheck: HealthCheck::default(),
             stopsignals: vec![types::StopSignal(SIGTERM)],
             stoptime: 5,
-            stdout: Some(types::WritableFile::from_path("/tmp/taskmaster_test.stdout")),
-            stderr: Some(types::WritableFile::from_path("/tmp/taskmaster_test.stderr")),
+            stdout: None,
+            stderr: None,
             env: Vec::new(),
         }
     }

--- a/src/conf/proc/defaults.rs
+++ b/src/conf/proc/defaults.rs
@@ -33,11 +33,3 @@ pub fn dflt_stopsignals() -> Vec<types::StopSignal> {
 pub fn dflt_stoptime() -> u8 {
     5
 }
-
-pub fn dflt_stdout() -> types::WritableFile {
-    types::WritableFile::default()
-}
-
-pub fn dflt_stderr() -> types::WritableFile {
-    types::WritableFile::default()
-}

--- a/src/conf/tests.rs
+++ b/src/conf/tests.rs
@@ -21,8 +21,8 @@ mod from_str {
         assert_eq!(conf.processes()["nginx"].exitcodes(), &defaults::dflt_exitcodes());
         assert_eq!(conf.processes()["nginx"].stopsignals(), &defaults::dflt_stopsignals());
         assert_eq!(conf.processes()["nginx"].stoptime(), defaults::dflt_stoptime());
-        assert_eq!(conf.processes()["nginx"].stdout(), "/tmp/nginx.stdout");
-        assert_eq!(conf.processes()["nginx"].stderr(), "/tmp/nginx.stderr");
+        assert!(conf.processes()["nginx"].stdout().is_none());
+        assert!(conf.processes()["nginx"].stderr().is_none());
         assert_eq!(conf.processes()["nginx"].env(), &Vec::new());
     }
 
@@ -385,8 +385,8 @@ mod from_file {
         assert_eq!(conf.processes()["sleep"].exitcodes(), &vec![0, 2]);
         assert_eq!(conf.processes()["sleep"].stopsignals(), &vec![StopSignal(SIGTERM), StopSignal(SIGUSR1)]);
         assert_eq!(conf.processes()["sleep"].stoptime(), 5);
-        assert_eq!(conf.processes()["sleep"].stdout(), ("/tmp/sleep.stdout".to_string()));
-        assert_eq!(conf.processes()["sleep"].stderr(), ("/tmp/sleep.stderr".to_string()));
+        assert_eq!(conf.processes()["sleep"].stdout().clone().unwrap().path(), ("/tmp/sleep.stdout".to_string()));
+        assert_eq!(conf.processes()["sleep"].stderr().clone().unwrap().path(), ("/tmp/sleep.stderr".to_string()));
         assert_eq!(
             conf.processes()["sleep"].env(),
             &vec![(("STARTED_BY".to_string()), ("abied-ch".to_string())), (("ANSWER".to_string()), ("42".to_string()))]

--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Deserializer, Serialize, de::Error};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -144,6 +146,15 @@ impl RequestStop {
 pub enum AttachFile {
     StdErr,
     StdOut,
+}
+
+impl Display for AttachFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AttachFile::StdErr => write!(f, "standard error"),
+            AttachFile::StdOut => write!(f, "standard output"),
+        }
+    }
 }
 
 impl TryFrom<&str> for AttachFile {

--- a/src/run/proc/tests.rs
+++ b/src/run/proc/tests.rs
@@ -3,6 +3,10 @@ use super::*;
 
 #[cfg(test)]
 mod tests {
+    use tokio::{fs::File, io::AsyncReadExt};
+
+    use crate::{conf::Config, run::daemon::Daemon};
+
     use super::*;
 
     #[test]
@@ -19,5 +23,42 @@ mod tests {
         };
 
         assert!(!proc.has_command_healthcheck());
+    }
+
+    #[tokio::test]
+    async fn configured_output() {
+        let mut proc = ProcessConfig::default();
+        let proc = proc
+            .set_cmd("python3")
+            .set_args(vec!["-c".into(), "import sys;print(f'stdout', flush=True);print(f'stderr',flush=True,file=sys.stderr)".into()])
+            .set_stdout("/tmp/stdout.stdout")
+            .set_stderr("/tmp/stderr.stderr")
+            .set_autostart(true);
+        let mut conf = Config::random();
+        let conf = conf.add_process("foo", proc.clone());
+        let mut daemon = Daemon::from_config(conf.clone(), "bar".into());
+
+        let _ = daemon.run_once().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = daemon.run_once().await;
+
+        let mut stdout = String::new();
+        File::open("/tmp/stdout.stdout")
+            .await
+            .unwrap()
+            .read_to_string(&mut stdout)
+            .await
+            .unwrap();
+
+        let mut stderr = String::new();
+        File::open("/tmp/stderr.stderr")
+            .await
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .await
+            .unwrap();
+
+        assert_eq!(stdout, "stdout\n".to_string());
+        assert_eq!(stderr, "stderr\n".to_string());
     }
 }


### PR DESCRIPTION
Closes #68 

Make `stdout` & `stderr` Options in `ProcessConfig`, discard the process' output if they are `None`.