### PR TITLE
Fix engine start output

### DIFF
--- a/config/healthcheck.toml
+++ b/config/healthcheck.toml
@@ -1,6 +1,5 @@
 socketpath = "/tmp/.taskmaster.sock"
 
-authgroup = "winstonallo"
 
 [processes.sleep]
 

--- a/config/unexisting_group.toml
+++ b/config/unexisting_group.toml
@@ -1,0 +1,7 @@
+authgroup = "asdpihgasbldkjalshdbliasjdlkasbdasd"
+
+[processes.sleep]
+cmd = "/usr/bin/sleep"
+args = ["1"]
+processes = 1
+workingdir = "/tmp"

--- a/src/bin/taskshell.rs
+++ b/src/bin/taskshell.rs
@@ -113,7 +113,7 @@ fn engine_running() -> bool {
 
 fn start_engine(config_path: &str) -> Result<String, String> {
     if engine_running() {
-        return Ok("taskmaster is already running".to_string());
+        return Ok("The Taskmaster is already running".to_string());
     }
 
     let mut child = match Command::new("cargo")
@@ -122,28 +122,35 @@ fn start_engine(config_path: &str) -> Result<String, String> {
         .spawn()
     {
         Ok(child) => child,
-        Err(e) => return Err(e.to_string()),
+        Err(e) => return Err(format!("Could not start Taskmaster engine: {e}")),
     };
 
-    let stderr = child.stderr.take().unwrap();
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            let _ = child.kill();
+            return Err("Could not start Taskmaster engine:\nNo output available from child process".into());
+        }
+    };
+
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let reader = std::io::BufReader::new(stderr);
-        for line in reader.lines().map_while(Result::ok) {
-            let _ = tx.send(line);
-        }
+        let mut reader = std::io::BufReader::new(stderr);
+        let mut output = String::new();
+        let _ = reader.read_to_string(&mut output);
+        let _ = tx.send(output);
     });
 
     let pid_file = Path::new(PID_FILE_PATH);
     for backoff in [5, 10, 20, 40, 80] {
         if pid_file.exists() {
-            return Ok("started taskmaster engine".to_string());
+            return Ok("Started Taskmaster engine".to_string());
         }
 
         if let Ok(stderr_output) = rx.try_recv() {
             if let Ok(Some(status)) = child.try_wait() {
                 if status.code() != Some(0) {
-                    return Err(format!("failed to start taskmaster engine: {stderr_output}"));
+                    return Err(format!("Could not start Taskmaster engine:\n\n{stderr_output}"));
                 }
             }
         }
@@ -153,7 +160,7 @@ fn start_engine(config_path: &str) -> Result<String, String> {
 
     let _ = child.kill();
 
-    Err("taskmaster engine not running after 15 seconds, no information on stderr - process was killed".to_string())
+    Err("Unexpected error: The Taskmaster engine is not running after 15 seconds, no information on stderr - process killed.".to_string())
 }
 
 fn build_request(command: &ShellCommand) -> BuildRequestResult {
@@ -318,7 +325,7 @@ async fn main() {
         _ => match handle_input(args).await {
             Ok(data) => print_raw_mode(&format!("{data}\n")),
             Err(e) => {
-                print_raw_mode(&format!("{e}\n"));
+                print_raw_mode(&format!("{e}"));
                 exit(1);
             }
         },

--- a/src/bin/taskshell.rs
+++ b/src/bin/taskshell.rs
@@ -325,7 +325,7 @@ async fn main() {
         _ => match handle_input(args).await {
             Ok(data) => print_raw_mode(&format!("{data}\n")),
             Err(e) => {
-                print_raw_mode(&format!("{e}"));
+                print_raw_mode(&e.to_string());
                 exit(1);
             }
         },

--- a/src/bin/taskshell.rs
+++ b/src/bin/taskshell.rs
@@ -1,6 +1,7 @@
 use std::{
     env::args,
-    io::{BufRead, Read},
+    fs,
+    io::Read,
     path::Path,
     process::{Command, Stdio, exit},
     sync::{atomic::AtomicU32, mpsc},
@@ -101,7 +102,13 @@ fn engine_running() -> bool {
         return true;
     }
 
-    Path::new(&format!("/proc/{pid}")).exists()
+    match Path::new(&format!("/proc/{pid}")).exists() {
+        true => true,
+        false => {
+            let _ = fs::remove_file(PID_FILE_PATH);
+            false
+        }
+    }
 }
 
 fn start_engine(config_path: &str) -> Result<String, String> {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,9 +1,12 @@
 use std::{collections::HashMap, error::Error, fs};
 
 #[cfg(test)]
-use defaults::{dflt_authgroup, dflt_logfile, dflt_socketpath};
+use defaults::{dflt_logfile, dflt_socketpath};
 
-use proc::{ProcessConfig, types::WritableFile};
+use proc::{
+    ProcessConfig,
+    types::{AuthGroup, WritableFile},
+};
 use serde::Deserialize;
 
 pub const PID_FILE_PATH: &str = "/tmp/taskmaster.pid";
@@ -31,8 +34,7 @@ pub struct Config {
     /// ```toml
     /// authgroup = "taskmaster"
     /// ```
-    #[serde(default = "defaults::dflt_authgroup")]
-    authgroup: String,
+    authgroup: Option<AuthGroup>,
 
     /// Path to the file the logs will be written to.
     ///
@@ -97,7 +99,7 @@ impl Config {
         &self.socketpath
     }
 
-    pub fn authgroup(&self) -> &str {
+    pub fn authgroup(&self) -> &Option<AuthGroup> {
         &self.authgroup
     }
 
@@ -111,7 +113,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             socketpath: dflt_socketpath(),
-            authgroup: dflt_authgroup(),
+            authgroup: None,
             logfile: dflt_logfile(),
             processes: HashMap::new(),
         }
@@ -125,8 +127,8 @@ impl Config {
         self
     }
 
-    pub fn set_authgroup(&mut self, authgroup: &str) -> &mut Self {
-        self.authgroup = authgroup.to_string();
+    pub fn set_authgroup(&mut self, authgroup: AuthGroup) -> &mut Self {
+        self.authgroup = Some(authgroup);
         self
     }
 

--- a/src/conf/proc/types.rs
+++ b/src/conf/proc/types.rs
@@ -1,3 +1,4 @@
+mod authgroup;
 mod autorestart;
 mod healthcheck;
 mod path;
@@ -5,6 +6,7 @@ mod stopsignal;
 mod umask;
 
 pub use self::{
+    authgroup::AuthGroup,
     autorestart::AutoRestart,
     healthcheck::{CommandHealthCheck, HealthCheck, HealthCheckType, UptimeHealthCheck},
     path::{AccessibleDirectory, ExecutableFile, WritableFile},

--- a/src/conf/proc/types/authgroup.rs
+++ b/src/conf/proc/types/authgroup.rs
@@ -1,0 +1,65 @@
+use serde::Deserialize;
+
+#[derive(Clone)]
+pub struct AuthGroup {
+    id: u32,
+    name: String,
+}
+
+impl AuthGroup {
+    pub fn from_group_name(group_name: &str) -> Result<Self, String> {
+        match get_group_id(&group_name) {
+            Ok(id) => Ok(AuthGroup { id, name: group_name.into() }),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn get_group_id(group_name: &str) -> Result<u32, String> {
+    let c_group = std::ffi::CString::new(group_name).map_err(|e| format!("{e}"))?;
+
+    unsafe {
+        let grp_ptr = libc::getgrnam(c_group.as_ptr());
+        if grp_ptr.is_null() {
+            Err(format!("Group '{group_name}' not found"))
+        } else {
+            Ok((*grp_ptr).gr_gid)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AuthGroup {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let group_name = String::deserialize(deserializer)?;
+        match AuthGroup::from_group_name(&group_name) {
+            Ok(group) => Ok(group),
+            Err(e) => Err(serde::de::Error::custom(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_group_id_success() {
+        assert_eq!(get_group_id("root").unwrap(), 0);
+    }
+
+    #[test]
+    fn get_group_id_nonexisting() {
+        assert!(get_group_id("randomaaaahgroup").is_err());
+    }
+}

--- a/src/conf/proc/types/authgroup.rs
+++ b/src/conf/proc/types/authgroup.rs
@@ -8,9 +8,9 @@ pub struct AuthGroup {
 
 impl AuthGroup {
     pub fn from_group_name(group_name: &str) -> Result<Self, String> {
-        match get_group_id(&group_name) {
+        match get_group_id(group_name) {
             Ok(id) => Ok(AuthGroup { id, name: group_name.into() }),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/jsonrpc/handlers.rs
+++ b/src/jsonrpc/handlers.rs
@@ -188,7 +188,7 @@ async fn update_attach_stream(file: &mut tokio::fs::File, pos: u64, len: u64, li
 
 async fn attach(socketpath: &str, to: &str, authgroup: &Option<AuthGroup>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut listener =
-        AsyncUnixSocket::new(socketpath, &authgroup).map_err(|e| Box::<dyn Error + Send + Sync>::from(format!("could not create new socket stream: {e}")))?;
+        AsyncUnixSocket::new(socketpath, authgroup).map_err(|e| Box::<dyn Error + Send + Sync>::from(format!("could not create new socket stream: {e}")))?;
 
     let mut file = tokio::fs::File::open(&to)
         .await

--- a/src/jsonrpc/handlers.rs
+++ b/src/jsonrpc/handlers.rs
@@ -9,6 +9,7 @@ use super::{
     response::ErrorCode,
 };
 use crate::{
+    conf::proc::types::AuthGroup,
     jsonrpc::{
         response::{ResponseResult, ResponseType},
         short_process::ShortProcess,
@@ -185,7 +186,7 @@ async fn update_attach_stream(file: &mut tokio::fs::File, pos: u64, len: u64, li
     Ok(pos)
 }
 
-async fn attach(socketpath: &str, to: &str, authgroup: String) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn attach(socketpath: &str, to: &str, authgroup: &Option<AuthGroup>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut listener =
         AsyncUnixSocket::new(socketpath, &authgroup).map_err(|e| Box::<dyn Error + Send + Sync>::from(format!("could not create new socket stream: {e}")))?;
 
@@ -221,7 +222,11 @@ pub struct AttachmentManager {
 }
 
 enum AttachmentRequest {
-    New { socketpath: String, to: String, authgroup: String },
+    New {
+        socketpath: String,
+        to: String,
+        authgroup: Option<AuthGroup>,
+    },
 }
 
 impl Default for AttachmentManager {
@@ -239,7 +244,7 @@ impl AttachmentManager {
                 match req {
                     AttachmentRequest::New { socketpath, to, authgroup } => {
                         tokio::spawn(async move {
-                            if let Err(e) = attach(&socketpath, &to, authgroup).await {
+                            if let Err(e) = attach(&socketpath, &to, &authgroup).await {
                                 if e.to_string().contains("Broken pipe") {
                                     log_info!("connection on {socketpath} closed");
                                     if let Ok(c_socketpath) = std::ffi::CString::new(socketpath.clone()) {
@@ -259,7 +264,7 @@ impl AttachmentManager {
         Self { tx }
     }
 
-    pub async fn attach(&self, socketpath: &str, to: &str, authgroup: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn attach(&self, socketpath: &str, to: &str, authgroup: &Option<AuthGroup>) -> Result<(), Box<dyn Error + Send + Sync>> {
         self.tx
             .send(AttachmentRequest::New {
                 socketpath: socketpath.to_owned(),

--- a/src/jsonrpc/handlers.rs
+++ b/src/jsonrpc/handlers.rs
@@ -574,7 +574,6 @@ mod tests {
     async fn reload_config_file_gone() {
         let conf = r#"
         socketpath = "/tmp/.taskmaster.sock"
-        authgroup = "winstonallo"
 
         [processes.sleep]
         cmd = "/usr/bin/sleep"

--- a/tests/configs/example.toml
+++ b/tests/configs/example.toml
@@ -4,11 +4,6 @@
 # Defaults to "/tmp/.taskmaster.sock".
 socketpath = "/tmp/.taskmaster.sock"
 
-# Name of the group to be created for authenticating client (similarly to 
-# the docker group.
-# Defaults to "taskmaster".
-authgroup = "winstonallo"
-
 # Process name.
 [processes.sleep]
 

--- a/tests/configs/sleep.toml
+++ b/tests/configs/sleep.toml
@@ -1,5 +1,4 @@
 socketpath = "/tmp/.taskmaster.sock"
-authgroup = "winstonallo"
 
 [processes.sleep]
 cmd = "/usr/bin/sleep"


### PR DESCRIPTION
Closes #71 

Improves monitoring of the child process when starting the engine via the shell (`engine start <config path>`), errors were not being reported if the pid file already existed.

```sh
$ cargo ts engine start config/unexisting_group.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/taskshell engine start config/unexisting_group.toml`
Could not start Taskmaster engine:

TOML parse error at line 1, column 13
  |
1 | authgroup = "asdpihgasbldkjalshdbliasjdlkasbdasd"
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Group 'asdpihgasbldkjalshdbliasjdlkasbdasd' not found
```

Also adds an `AuthGroup` type to check the validity of the authgroup field at deserialization time.